### PR TITLE
Set directories using commandline args, add .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "airbnb-base",
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "no-console": "off",
+        "max-len": "off"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This script is used by me to automate the obfuscation + build process for some o
 
 1. Cleans your dist folder
 2. Obfuscates your JavaScript files in your selected source folders
-3. Checks for Dependencies in your package.json file which should be listed under dev-dependencies
+3. Checks for dependencies in your package.json file which should be listed under devDependencies
 4. Builds the electron app with the local electron-builder installation
 5. Makes a hard git reset (So you can continue working with your non-obfuscated files)
 
@@ -23,11 +23,10 @@ Install the needed dependencies: [javascript-obfuscator](https://github.com/java
 
 Edit some variables to fit your environment/needs: 
   - dist folder (line 6)
-  - source folder list (line 14)
-  - javascript-obfuscator config (line 19 to 24)
-  - dev dependencies (line 31)
+  - javascript-obfuscator config (lines 26-30)
+  - dev dependencies (line 37)
   
-Run it with: `npm run build win mac linux`
+Run it with: `npm run build js/ classes/ --win --mac --linux`
 And it will try to build for all 3 platforms, if it's possible (Only on mac AFAIK)
 
 

--- a/build.js
+++ b/build.js
@@ -15,7 +15,7 @@ for (let index = 2; index < process.argv.length; index += 1) {
   }
 }
 console.log('Building for:');
-targets.forEach(target => console.log(target.substring(2)));
+targets.forEach((target) => console.log(target.substring(2)));
 
 // obfuscate files
 dirs.forEach((dir) => {

--- a/build.js
+++ b/build.js
@@ -4,14 +4,20 @@ const { execFile } = require('child_process');
 
 console.log('Cleaning dist folder...');
 fs.emptyDirSync('dist');
-console.log('Building for:');
+
+const dirs = [];
 const targets = [];
 for (let index = 2; index < process.argv.length; index += 1) {
-  console.log(process.argv[index]);
-  targets.push(`--${process.argv[index]}`);
+  if (process.argv[index].startsWith('--')) {
+    targets.push(process.argv[index]);
+  } else {
+    dirs.push(process.argv[index]);
+  }
 }
+console.log('Building for:');
+targets.forEach(target => console.log(target.substring(2)));
+
 // obfuscate files
-const dirs = ['js/', 'classes/'];
 dirs.forEach((dir) => {
   fs.readdirSync(dir).forEach((file) => {
     const path = `${dir}${file}`;


### PR DESCRIPTION
These changes allow users to specify the source directories from the commandline instead of having them hardcoded in the script.